### PR TITLE
Feature/controller autoload fallback

### DIFF
--- a/Autoload.php
+++ b/Autoload.php
@@ -135,13 +135,22 @@ class Varien_Autoload
     private function findMagentoControllerFile($class){
         //By convention this is the first 2 "words" of the class name
         $classParts = explode('_', $class);
-        $realModule = array_shift($classParts) . '_' . array_shift($classParts);
 
-        $fileNameWithPath = implode(DIRECTORY_SEPARATOR, $classParts);
+        if (!(isset($classParts[0]) && isset($classParts[1]))) {
+            //Namespace and module name are not defined.
+            return false;
+        }
+        $namespace = array_shift($classParts);
+        $module = array_shift($classParts);
+
+        $realModule = $namespace . '_' . $module;
+
+        $fileNameWithPath = implode(DIRECTORY_SEPARATOR, $classParts) . '.php';
         $moduleDir = Mage::getModuleDir('controllers', $realModule);
 
-        if (file_exists($moduleDir . DIRECTORY_SEPARATOR . $fileNameWithPath . '.php')) {
-            return $moduleDir . DIRECTORY_SEPARATOR . $fileNameWithPath . '.php';
+        $fullFilepath = $moduleDir . DIRECTORY_SEPARATOR . $fileNameWithPath;
+        if (file_exists($fullFilepath)) {
+            return $fullFilepath;
         }
 
         return false;


### PR DESCRIPTION
PR https://github.com/joshdifabio/magento1-composer-bridge/pull/5 added the ability to "autoload" controller classes. This pseudo autoloading always uses the modules installed directory as it's base, then looks in the `controllers` directory beneath it.

Since we're emulating autoloading I figured we should also support the fallback method.

This update allows you to do `new Mage_Adminhtml_Sales_OrderController` and get a controller living at  `app/code/local/Mage/Adminhtml/controllers/Sales/OrderController.php` rather than `app/code/core/Mage/Adminhtml/controllers/Sales/OrderController.php`.

This works well for anything calling `new ControllerClassName` or `extends ControllerClassName`. 

However as Magento does not actually load controllers like this there is also a core amendment that must be made to make sure `new`, `extends` and the standard magento router all pick up and respect the fallback controller classes.

`Mage_Core_Controller_Varien_Router_Standard::getControllerFileName`

``` diff
    public function getControllerFileName($realModule, $controller)
    {
+       $className = $this->getControllerClassName($realModule, $controller);
+       if ($file = mageFindClassFile($className)) {
+           return $file;
+       }

        $parts = explode('_', $realModule);
        $realModule = implode('_', array_splice($parts, 0, 2));
        $file = Mage::getModuleDir('controllers', $realModule);
        if (count($parts)) {
            $file .= DS . implode(DS, $parts);
        }
        $file .= DS.uc_words($controller, DS).'Controller.php';
        return $file;
    }
```
