### PR TITLE
Add 'hash_equals' function - used by SUPEE-8788 security patch

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -362,3 +362,42 @@ if ( !function_exists('sys_get_temp_dir') ) {
         }
     }
 }
+
+if (!function_exists('hash_equals')) {
+    /**
+     * Compares two strings using the same time whether they're equal or not.
+     * A difference in length will leak
+     *
+     * Added here to support use of 'hash_equals' by SUPEE-8788 Magento security patch - 'hash_equals' only exists
+     * in PHP 5 >= 5.6.0
+     * http://magento.stackexchange.com/questions/140550/security-patch-supee-8788-possible-problems/140664#140664
+     *
+     * @param string $known_string
+     * @param string $user_string
+     * @return boolean Returns true when the two strings are equal, false otherwise.
+     */
+    function hash_equals($known_string, $user_string)
+    {
+        $result = 0;
+
+        if (!is_string($known_string)) {
+            trigger_error("hash_equals(): Expected known_string to be a string", E_USER_WARNING);
+            return false;
+        }
+
+        if (!is_string($user_string)) {
+            trigger_error("hash_equals(): Expected user_string to be a string", E_USER_WARNING);
+            return false;
+        }
+
+        if (strlen($known_string) != strlen($user_string)) {
+            return false;
+        }
+
+        for ($i = 0; $i < strlen($known_string); $i++) {
+            $result |= (ord($known_string[$i]) ^ ord($user_string[$i]));
+        }
+
+        return 0 === $result;
+    }
+}


### PR DESCRIPTION
- Magento security patch SUPEE-8788 makes use of the `hash_equals` PHP function
- 'hash_equals' does not exist in PHP versions < 5.6.0
- See http://magento.stackexchange.com/questions/140550/security-patch-supee-8788-possible-problems/140664#140664
